### PR TITLE
chore: deprecated된 property 구문 삭제

### DIFF
--- a/distributed-mail/src/main/resources/application.yml
+++ b/distributed-mail/src/main/resources/application.yml
@@ -8,7 +8,6 @@ spring:
   jpa:
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQL8Dialect
         format_sql: true
         show_sql: false
         hbm2ddl.auto: none

--- a/ticket/src/main/resources/application.yml
+++ b/ticket/src/main/resources/application.yml
@@ -8,7 +8,6 @@ spring:
   jpa:
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQL8Dialect
         format_sql: true
         show_sql: true
         hbm2ddl.auto: validate

--- a/trend-item/src/main/resources/application.yml
+++ b/trend-item/src/main/resources/application.yml
@@ -11,7 +11,6 @@ spring:
   jpa:
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQL8Dialect
         format_sql: true
         show_sql: true
         hbm2ddl.auto: update


### PR DESCRIPTION
1. `MySQL8Dialect`는 deprecated되어 `MySQLDialect`를 사용하라고 합니다. 이는 hibernate 6부터 deprecated되었어요 ([ref](https://docs.jboss.org/hibernate/orm/6.0/migration-guide/migration-guide.html#_dialects))
2. 추가로, `hibernate.dialect`를 자동으로 설정하는 기능은 Hibernate 3.2부터 제공하는 것처럼 보이네요. ([ref](https://docs.jboss.org/hibernate/orm/5.3/userguide/html_single/Hibernate_User_Guide.html#portability-dialectresolver))

그래서 각 문제에서 해당 구문을 삭제했어요. 확인해주세요~!

```
2024-12-03T22:24:12.069+09:00  WARN 39255 --- [           main] org.hibernate.orm.deprecation            : HHH90000025: MySQL8Dialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
2024-12-03T22:24:12.069+09:00  WARN 39255 --- [           main] org.hibernate.orm.deprecation            : HHH90000026: MySQL8Dialect has been deprecated; use org.hibernate.dialect.MySQLDialect instead
```